### PR TITLE
AWS filtering from custom tags in yaml config

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ You will need to install the following
 *   Jinja2
 *   boto
 *   apscheduler
+*   pyyaml
 
 After that you can run 
 python bin/run.py

--- a/elasticd/ext/aws_resource_locator.py
+++ b/elasticd/ext/aws_resource_locator.py
@@ -13,10 +13,22 @@ class AWSinstanceLocator(ResourceLocator):
         ec2 = boto.connect_ec2()
         #search for the backend servers
         #todo read the filter from configuration
-        reservations = ec2.get_all_instances(filters={'tag:AGS': 'fnrw',
-                                                      'tag:SDLC': 'DEV',
-                                                      'tag:Purpose': 'finra.org_drupal',
-                                                      'instance-state-name': 'running'})
+        reservations = ec2.get_all_instances()
+
+        # Build set of filters for instance lookup
+        configItems = self._get_all_config_items()
+        filterDict = {}
+
+        # Add tag filters from config
+        for item in configItems:
+            if (item[0].startswith('aws_tag')):
+                tagKey = "tag:" + item[0].split('_')[2] 
+                filterDict[tagKey] = item[1] 
+        
+
+        # Add instance state filter
+        filterDict['instance-state-name']: 'running'
+        reservations = ec2.get_all_instances(filters = filterDict)
         instances = [i for reservation in reservations for i in reservation.instances]
         backends = []
         for server in instances:

--- a/elasticd/ext/aws_resource_locator.py
+++ b/elasticd/ext/aws_resource_locator.py
@@ -12,8 +12,6 @@ class AWSinstanceLocator(ResourceLocator):
         ResourceLocator.get_resources(self)
         ec2 = boto.connect_ec2()
         #search for the backend servers
-        #todo read the filter from configuration
-        reservations = ec2.get_all_instances()
 
         # Build set of filters for instance lookup
         configItems = self._get_all_config_items()
@@ -27,7 +25,7 @@ class AWSinstanceLocator(ResourceLocator):
         
 
         # Add instance state filter
-        filterDict['instance-state-name']: 'running'
+        filterDict['instance-state-name'] = 'running'
         reservations = ec2.get_all_instances(filters = filterDict)
         instances = [i for reservation in reservations for i in reservation.instances]
         backends = []

--- a/elasticd/ext/aws_resource_locator.py
+++ b/elasticd/ext/aws_resource_locator.py
@@ -22,7 +22,6 @@ class AWSinstanceLocator(ResourceLocator):
         #search for the backend servers
 
         # Build set of filters for instance lookup
-        configItems = self._get_all_config_items()
         filterDict = {}
 
         # Add tag filters from config

--- a/elasticd/plugins.py
+++ b/elasticd/plugins.py
@@ -43,6 +43,13 @@ class BasePlugin():
         """
         return self._config.get(self._config_section, name)
 
+    def _get_all_config_items(self):
+        """
+        Gets a list of tuples for all key values pairs in
+        this section
+        :return:  All items from this config section
+        """
+        return self.config.items(self._config_section)
 
 class Datastore(BasePlugin):
     def __init__(self, config):

--- a/elasticd/plugins.py
+++ b/elasticd/plugins.py
@@ -49,7 +49,7 @@ class BasePlugin():
         this section
         :return:  All items from this config section
         """
-        return self.config.items(self._config_section)
+        return self._config.items(self._config_section)
 
 class Datastore(BasePlugin):
     def __init__(self, config):

--- a/elasticd/plugins.py
+++ b/elasticd/plugins.py
@@ -43,14 +43,6 @@ class BasePlugin():
         """
         return self._config.get(self._config_section, name)
 
-    def _get_all_config_items(self):
-        """
-        Gets a list of tuples for all key values pairs in
-        this section
-        :return:  All items from this config section
-        """
-        return self._config.items(self._config_section)
-
 class Datastore(BasePlugin):
     def __init__(self, config):
         """Datastore plugins are used to store the ip address information for all known backend hosts.

--- a/test-conf/aws.yaml
+++ b/test-conf/aws.yaml
@@ -1,0 +1,11 @@
+# AWS yaml test config
+aws_tags:
+    tag_sdlc:
+        key: "SDLC"
+        value: "DEV"
+    tag_ags:
+        key: "AGS"
+        value: "FNRW"
+    tag_role:
+        key: "role"
+        value: "fnrw-app"

--- a/test-conf/settings.arl.cfg
+++ b/test-conf/settings.arl.cfg
@@ -1,7 +1,3 @@
-##
-# Copy settings.cfg.default to settigns.cfg to get started.
-##
-
 [DEFAULT]
 # How often to check for new resources in seconds.
 locate_interval=10
@@ -13,19 +9,6 @@ driver_interval=5
 # Start the flask web service.
 start_server = false
 
-##
-# Log File Location
-#
-# @note Make sure that this location exists.
-##
-log_file = /var/log/elasticd/combined.log
-
-##
-# Log Level
-#
-# @see https://docs.python.org/2/library/logging.html#logging-levels
-##
-log_level = 10
 
 ##
 # Plugins
@@ -44,15 +27,12 @@ plugin_class = InmemoryDatastore
 module_name = elasticd.ext.varnish_driver
 plugin_class = VarnishDriver
 templates_path = /../../templates
-template_name = backend.vcl
-vcl_output_path = .
-vcl_output_name = backend.vcl
-varnish_reload = False
+backend_vcl_path = backend.vcl
 
 
 [resource-locator]
-#module_name = elasticd.ext.aws_resource_locator
-#plugin_class = AWSinstanceLocator
+module_name = elasticd.ext.aws_resource_locator
+plugin_class = AWSinstanceLocator
 
-module_name = elasticd.ext.mock_resource_locator
-plugin_class = MockResourceLocator
+aws_tag_SDLC = DEV
+aws_tag_role = fnrw-app

--- a/test-conf/settings.arl.cfg
+++ b/test-conf/settings.arl.cfg
@@ -28,4 +28,4 @@ backend_vcl_path = backend.vcl
 module_name = elasticd.ext.aws_resource_locator
 plugin_class = AWSinstanceLocator
 
-aws_config = '../../test-conf/aws.yaml'
+aws_config = ../../test-conf/aws.yaml

--- a/test-conf/settings.arl.cfg
+++ b/test-conf/settings.arl.cfg
@@ -9,7 +9,6 @@ driver_interval=5
 # Start the flask web service.
 start_server = false
 
-
 ##
 # Plugins
 #
@@ -19,20 +18,14 @@ start_server = false
 module_name = elasticd.ext.inmemory_datastore
 plugin_class = InmemoryDatastore
 
-#module_name = elasticd.ext.sqlite_datastore
-#plugin_class = SqliteDatastore
-
-
 [driver]
 module_name = elasticd.ext.varnish_driver
 plugin_class = VarnishDriver
 templates_path = /../../templates
 backend_vcl_path = backend.vcl
 
-
 [resource-locator]
 module_name = elasticd.ext.aws_resource_locator
 plugin_class = AWSinstanceLocator
 
-aws_tag_SDLC = DEV
-aws_tag_role = fnrw-app
+aws_config = '../../test-conf/aws.yaml'

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -8,7 +8,10 @@ import os
 import ConfigParser
 
 def get_test_plugin_manager():
-    config_file = os.path.dirname(os.path.realpath(__file__)) + '/../test-conf/settings.cfg'
+    get_test_plugin_manager('settings.cfg')
+
+def get_test_plugin_manager(settings_file):
+    config_file = os.path.dirname(os.path.realpath(__file__)) + '/../test-conf/' + settings_file
     config_file = os.path.realpath(config_file)
 
     config = ConfigParser.ConfigParser()

--- a/test/test_aws_resource_locator.py
+++ b/test/test_aws_resource_locator.py
@@ -1,4 +1,5 @@
 from test import *
+import elasticd.resource
 
 class TestAWSResourceLocator(unittest.TestCase):
     def test_init(self):
@@ -7,9 +8,10 @@ class TestAWSResourceLocator(unittest.TestCase):
 
         _resource_locator = _plugin_manager.get_resource_locator()
 
-
         self._test_obj(_resource_locator, ResourceLocator)
         resources = _resource_locator.get_resources()
+        # Check if list
+        self.assertNotIsInstance(resources, basestring)
 
     def _test_obj(self, obj, cls):
         self.assertIsNotNone(obj)

--- a/test/test_aws_resource_locator.py
+++ b/test/test_aws_resource_locator.py
@@ -1,0 +1,21 @@
+from test import *
+
+class TestAWSResourceLocator(unittest.TestCase):
+    def test_init(self):
+        _plugin_manager = get_test_plugin_manager('settings.arl.cfg')
+        self.assertIsNotNone(_plugin_manager)
+
+        _resource_locator = _plugin_manager.get_resource_locator()
+
+
+        self._test_obj(_resource_locator, ResourceLocator)
+        resources = _resource_locator.get_resources()
+
+    def _test_obj(self, obj, cls):
+        self.assertIsNotNone(obj)
+        self.assertTrue(isinstance(obj, BasePlugin), '%s does not extend base plugin' % obj)
+        self.assertTrue(isinstance(obj, cls), '%s does not extend %s' % (obj, cls))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Updated AWS Resource Locator to load YAML of tag keys and values
- Construct ec2 instances filter from specified tags and values
- Add a test of this (note - test is not portable)

Credits to @bryantrobbins
